### PR TITLE
Add visuals to dfs

### DIFF
--- a/frontend/src/BasicSearches.ts
+++ b/frontend/src/BasicSearches.ts
@@ -157,26 +157,50 @@ const graph: AdjacencyList = {
 
 // Lets start off with the basics.
 
-function dfs(
+export function dfsOld(
   graph: AdjacencyList,
-  start: Vertex,
+  currentVertex: Vertex,
   visited: Set<Vertex> = new Set()
 ): void {
   // Note that this function is technically void - the real output are the side effects, the console.log
   // Mark the current node as visited
-  visited.add(start);
-  console.log(start); // Print or process the node
+  visited.add(currentVertex);
+  console.log(currentVertex); // Print or process the node
 
   // Recur for all the vertices adjacent to this vertex
-  for (const neighbor of graph[start]) {
+  for (const neighbor of currentVertex) {
+    // For each of the neighbors of A...  // START IS A VERTEX! - FIRST ITERATION IS A!
     if (!visited.has(neighbor)) {
-      dfs(graph, neighbor, visited);
+      dfsOld(graph, neighbor, visited);
     }
   }
 }
 
+// dfs
+export function dfs(
+  graph: AdjacencyList,
+  currentVertex: Vertex,
+  visited: Set<Vertex> = new Set<Vertex>(), // Specify Set<Vertex> type
+  traversal: Vertex[] = [] // Specify Vertex[] type for traversal array
+): Vertex[] {
+  // Mark the current node as visited
+  visited.add(currentVertex);
+  traversal.push(currentVertex);
+
+  // Recur for all the vertices adjacent to this vertex
+  for (const neighbor of graph[currentVertex]) {
+    if (!visited.has(neighbor)) {
+      dfs(graph, neighbor, visited, traversal);
+    }
+  }
+
+  return traversal;
+}
+
+// To think of graph[currentVertex] think of arr[i], same exact thing
+
 // Start DFS traversal from node 'A'
-dfs(graph, "D");
+dfsOld(graph, "D");
 
 // And now, BFS
 

--- a/frontend/src/dfs.ts
+++ b/frontend/src/dfs.ts
@@ -15,7 +15,7 @@ const graph: AdjacencyList = {
   G: ["D"],
 };
 
-function dfs(
+export function dfs(
   graph: AdjacencyList,
   currentVertex: Vertex,
   target: Vertex,

--- a/frontend/src/pages/DFS.tsx
+++ b/frontend/src/pages/DFS.tsx
@@ -1,0 +1,76 @@
+// DFS.js
+import React, { useState, useEffect } from 'react';
+import { dfs } from '../BasicSearches'; // Import the dfs function
+
+function DFS() {
+    const [traversalOrder, setTraversalOrder] = useState([]);
+
+    const graph = {
+        A: ["B", "C"],
+        B: ["A", "D", "E"],
+        C: ["A", "F"],
+        D: ["B"],
+        E: ["B", "F"],
+        F: ["C", "E"],
+    };
+
+    const nodePositions = {
+        A: { x: 200, y: 100 },
+        B: { x: 100, y: 200 },
+        C: { x: 300, y: 200 },
+        D: { x: 50, y: 300 },
+        E: { x: 150, y: 300 },
+        F: { x: 250, y: 300 },
+    };
+
+    const handleDFS = () => {
+        const traversal = dfs(graph, 'A'); // Get the traversal order from your dfs function
+        setTraversalOrder([]); // Clear the traversal order initially
+
+        traversal.forEach((node, index) => {
+            setTimeout(() => {
+                // Update the traversal order step by step with delay
+                setTraversalOrder(prev => [...prev, node]);
+            }, index * 500); // 500ms delay between each node (adjust as needed)
+        });
+    };
+
+    const Node = ({ node }) => {
+        const isVisited = traversalOrder.includes(node);
+        const fillColor = isVisited ? 'orange' : 'lightblue';
+
+        return (
+            <g key={node}>
+                <circle cx={nodePositions[node].x} cy={nodePositions[node].y} r="20" fill={fillColor} stroke="blue" />
+                <text x={nodePositions[node].x} y={nodePositions[node].y} textAnchor="middle" dy=".3em">{node}</text>
+            </g>
+        );
+    };
+
+    const Edge = ({ start, end }) => (
+        <line
+            key={`${start}-${end}`}
+            x1={nodePositions[start].x}
+            y1={nodePositions[start].y}
+            x2={nodePositions[end].x}
+            y2={nodePositions[end].y}
+            stroke="gray"
+        />
+    );
+
+    return (
+        <div className="p-4">
+            <h2 className="text-xl font-bold mb-4">DFS Graph Visualization</h2>
+            <button onClick={handleDFS} className="mb-4 px-4 py-2 bg-blue-500 text-white rounded">Run DFS</button>
+            <svg width="400" height="400" className="border border-gray-300">
+                {Object.entries(graph).map(([node, neighbors]) =>
+                    neighbors.map(neighbor => <Edge key={`${node}-${neighbor}`} start={node} end={neighbor} />)
+                )}
+                {Object.keys(graph).map(node => <Node key={node} node={node} />)}
+            </svg>
+            <p className="mt-4">Traversal Order: {traversalOrder.join(' -> ')}</p>
+        </div>
+    );
+}
+
+export default DFS;

--- a/frontend/src/pages/Searches.tsx
+++ b/frontend/src/pages/Searches.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import LinearSearch from './LinearSearch';
-
+import DFS from './DFS';
 
 const Searches: React.FC = () => {
     const [selectedOption, setSelectedOption] = useState<string>('');
@@ -18,12 +18,12 @@ const Searches: React.FC = () => {
             >
                 <option value="">Select an option</option>
                 <option value="LinearSearch">LinearSearch</option>
-                <option value="option2">Option 2</option>
+                <option value="DFS">DFS</option>
                 <option value="option3">Option 3</option>
             </select>
             <div className="mt-2">
                 {selectedOption === 'LinearSearch' && <LinearSearch />}
-                {selectedOption === 'option2' && <p>Content for Option 2</p>}
+                {selectedOption === 'DFS' && <DFS />}
                 {selectedOption === 'option3' && <p>Content for Option 3</p>}
             </div>
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add DFS visualization feature using updated `dfs` function and integrate into search options.
> 
>   - **DFS Visualization**:
>     - Adds `DFS.tsx` to visualize DFS traversal with nodes and edges.
>     - Uses `dfs` from `BasicSearches.ts` to get traversal order.
>     - Displays traversal order with a 500ms delay between nodes.
>   - **Function Updates**:
>     - Renames `dfs` to `dfsOld` in `BasicSearches.ts` and adds a new `dfs` function that returns traversal order.
>   - **UI Changes**:
>     - Updates `Searches.tsx` to include `DFS` in the dropdown menu.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fisaac.algo-visuals&utm_source=github&utm_medium=referral)<sup> for e5720be81b6d322098728d0959b1b9abb1c3a0a9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->